### PR TITLE
Add role reactions for base_conversation roles

### DIFF
--- a/feubot.py
+++ b/feubot.py
@@ -8,6 +8,7 @@ from sys import argv
 # from feubotFormatter import FeubotFormatter
 from discord.ext.commands import DefaultHelpCommand
 
+import roles
 
 def setupBot(bot):
     import helpful, memes, reactions, other#, undelete
@@ -61,54 +62,30 @@ if __name__ == "__main__":
     @bot.event
     async def on_raw_reaction_add(payload):
         messageID = payload.message_id
-        try:
-            with open("BCRoleReaction.txt", "r") as file:
-                reactMessage = int(file.read())
+        reaction = payload.emoji.name
 
-        except (FileNotFoundError, IOError):
-            return
+        role_name = roles.find_role(str(messageID), reaction)
 
-        if messageID == reactMessage:
-            guild_id = payload.guild_id
-            guild = discord.utils.find(lambda g : g.id == guild_id, bot.guilds)
-
-            if payload.emoji.name == "🐱":
-                role = discord.utils.get(guild.roles, name="Catposting")
-            elif payload.emoji.name == "🦎":
-                role = discord.utils.get(guild.roles, name="Lizardposting")
-            elif payload.emoji.name == "🐶":
-                role = discord.utils.get(guild.roles, name="Dogposting")
-
+        if role_name:
+            guild = discord.utils.find(lambda g : g.id == payload.guild_id, bot.guilds)
+            member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
+            role = discord.utils.get(guild.roles, name=role_name)
             if role:
-                member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
-                if member:
-                    await member.add_roles(role)
+                await member.add_roles(role)
 
     @bot.event
     async def on_raw_reaction_remove(payload):
         messageID = payload.message_id
-        try:
-            with open("BCRoleReaction.txt", "r") as file:
-                reactMessage = int(file.read())
+        reaction = payload.emoji.name
 
-        except (FileNotFoundError, IOError):
-            return
+        role_name = roles.find_role(str(messageID), reaction)
 
-        if messageID == reactMessage:
-            guild_id = payload.guild_id
-            guild = discord.utils.find(lambda g : g.id == guild_id, bot.guilds)
-
-            if payload.emoji.name == "🐱":
-                role = discord.utils.get(guild.roles, name="Catposting")
-            elif payload.emoji.name == "🦎":
-                role = discord.utils.get(guild.roles, name="Lizardposting")
-            elif payload.emoji.name == "🐶":
-                role = discord.utils.get(guild.roles, name="Dogposting")
-
+        if role_name:
+            guild = discord.utils.find(lambda g : g.id == payload.guild_id, bot.guilds)
+            member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
+            role = discord.utils.get(guild.roles, name=role_name)
             if role:
-                member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
-                if member:
-                    await member.remove_roles(role)
+                await member.remove_roles(role)
 
     @bot.add_listener
     async def on_command_error(ctx, error):

--- a/feubot.py
+++ b/feubot.py
@@ -58,6 +58,58 @@ if __name__ == "__main__":
         print('------')
         await bot.change_presence(activity=discord.Game(name="Reading the doc!"))
 
+    @bot.event
+    async def on_raw_reaction_add(payload):
+        messageID = payload.message_id
+        try:
+            with open("BCRoleReaction.txt", "r") as file:
+                reactMessage = int(file.read())
+
+        except (FileNotFoundError, IOError):
+            return
+
+        if messageID == reactMessage:
+            guild_id = payload.guild_id
+            guild = discord.utils.find(lambda g : g.id == guild_id, bot.guilds)
+
+            if payload.emoji.name == "🐱":
+                role = discord.utils.get(guild.roles, name="Catposting")
+            elif payload.emoji.name == "🦎":
+                role = discord.utils.get(guild.roles, name="Lizardposting")
+            elif payload.emoji.name == "🐶":
+                role = discord.utils.get(guild.roles, name="Dogposting")
+
+            if role:
+                member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
+                if member:
+                    await member.add_roles(role)
+
+    @bot.event
+    async def on_raw_reaction_remove(payload):
+        messageID = payload.message_id
+        try:
+            with open("BCRoleReaction.txt", "r") as file:
+                reactMessage = int(file.read())
+
+        except (FileNotFoundError, IOError):
+            return
+
+        if messageID == reactMessage:
+            guild_id = payload.guild_id
+            guild = discord.utils.find(lambda g : g.id == guild_id, bot.guilds)
+
+            if payload.emoji.name == "🐱":
+                role = discord.utils.get(guild.roles, name="Catposting")
+            elif payload.emoji.name == "🦎":
+                role = discord.utils.get(guild.roles, name="Lizardposting")
+            elif payload.emoji.name == "🐶":
+                role = discord.utils.get(guild.roles, name="Dogposting")
+
+            if role:
+                member = discord.utils.find(lambda m : m.id == payload.user_id, guild.members)
+                if member:
+                    await member.remove_roles(role)
+
     @bot.add_listener
     async def on_command_error(ctx, error):
         if type(error) == commands.CheckFailure:

--- a/other.py
+++ b/other.py
@@ -150,12 +150,12 @@ class Other(commands.Cog):
 
     @commands.command()
     @developerCheck
-    async def unsetReactionRole(self, ctx, messageID, role):
+    async def unsetReactionRole(self, ctx, messageID, reaction):
         """
         Admins only. Removes a specified reaction role from a specified message.
         Using "ALL" as the role argument will remove all reaction roles
         """
-        return_string = roles.delete_role(str(messageID), role)
+        return_string = roles.delete_reaction_role(str(messageID), reaction)
         await ctx.send(return_string)
 
     @commands.command()

--- a/other.py
+++ b/other.py
@@ -7,7 +7,7 @@ from functools import reduce
 import cloudinary, cloudinary.uploader, cloudinary.api, urllib
 import roles
 
-developerIDs = (91393737950777344, 171863408822452224, 146075481534365697, 864898945981218837)
+developerIDs = (91393737950777344, 171863408822452224, 146075481534365697)
 developerCheck = commands.check(lambda x: x.message.author.id in developerIDs)
 
 cl_name = os.environ.get('CLOUDNAME', default=None)

--- a/other.py
+++ b/other.py
@@ -140,6 +140,24 @@ class Other(commands.Cog):
         except SystemExit:
             await ctx.send("I tried to quit().")
 
+    @commands.command()
+    @developerCheck
+    async def setBCRoleReaction(self, ctx, messageID):
+        """Admins only. Sets a message to grant roles based on reactions"""
+        with open("BCRoleReaction.txt", "w") as file:
+            file.write(str(messageID))
+            await ctx.send("#base_conversations reaction roles are now active!")
+
+    @commands.command()
+    @developerCheck
+    async def unsetBCRoleReaction(self, ctx):
+        """Admins only. Removes the currently set message that grants roles based on reactions"""
+        try:
+            os.remove("BCRoleReaction.txt")
+            await ctx.send("#base_conversations reaction roles are now inactive!")
+        except (FileNotFoundError, IOError):
+            await ctx.send("There is no reaction role message file to delete")
+
     # @commands.command()
     # async def cltest(self, ctx):
     #     filename = "test2.txt"

--- a/other.py
+++ b/other.py
@@ -7,7 +7,7 @@ from functools import reduce
 import cloudinary, cloudinary.uploader, cloudinary.api, urllib
 import roles
 
-developerIDs = (91393737950777344, 171863408822452224, 146075481534365697)
+developerIDs = (91393737950777344, 171863408822452224, 146075481534365697, 864898945981218837)
 developerCheck = commands.check(lambda x: x.message.author.id in developerIDs)
 
 cl_name = os.environ.get('CLOUDNAME', default=None)
@@ -145,8 +145,11 @@ class Other(commands.Cog):
     @developerCheck
     async def setReactionRole(self, ctx, messageID, role, reaction):
         """Admins only. Sets a reaction role on a specified message"""
-        roles.add_role(str(messageID), reaction, role)
-        await ctx.send(f"{role} for {reaction} reaction set")
+        if messageID.isdigit():
+            roles.add_role(str(messageID), reaction, role)
+            await ctx.send(f"{role} for {reaction} reaction set")
+        else:
+            await ctx.send("Invalid messageID")
 
     @commands.command()
     @developerCheck
@@ -166,8 +169,16 @@ class Other(commands.Cog):
         reactRoles = roles.read_roles()
 
         for a, b in reactRoles.items():
-            messageID_link = await ctx.fetch_message(int(a))
-            return_string += f"<{messageID_link.jump_url}>:\n"
+            try:
+                messageID_link = await ctx.fetch_message(int(a))
+            except (ValueError):
+                messageID_link = None
+
+            if messageID_link:
+                return_string += f"<{messageID_link.jump_url}>:\n"
+            else:
+                return_string += f"{a}:\n"
+
             for x, y in b.items():
                 if (discord.utils.get(ctx.guild.roles, name=y)):
                     return_string += f"        {x}: {y}\n"

--- a/roles.py
+++ b/roles.py
@@ -31,11 +31,10 @@ def add_role(messageID, reaction, role):
         pickle.dump(roleReact_db, file)
         print(roleReact_db)
 
-def delete_role(messageID, reaction):
+def delete_reaction_role(messageID, reaction):
     roleReact_db = read_roles()
     if not roleReact_db:
-        print("file is empty")
-        return
+        return("There are no role reactions set")
 
     if reaction == "ALL" and messageID in roleReact_db:
         roleReact_db.pop(messageID)

--- a/roles.py
+++ b/roles.py
@@ -1,0 +1,66 @@
+import pickle
+import sys
+
+ROLE_FILE = "Roles.pickle"
+
+#Internal function for reading and returning the contents of the roles file
+def read_roles():
+    try:
+        open(ROLE_FILE, "rb")
+    except (FileNotFoundError, IOError):
+        open(ROLE_FILE, "wb")
+
+    finally:
+        with open(ROLE_FILE, "rb") as file:
+            if file.read(1):
+                file.seek(0)
+                db = pickle.load(file)
+                return db
+
+def add_role(messageID, reaction, role):
+    roleReact_db = read_roles() 
+    if not roleReact_db:
+        roleReact_db = {}
+
+    if messageID not in roleReact_db:
+        bar = {messageID: {reaction: role}}
+        roleReact_db.update(bar)
+
+    with open(ROLE_FILE, "wb") as file:
+        roleReact_db[messageID][reaction] = role
+        pickle.dump(roleReact_db, file)
+        print(roleReact_db)
+
+def delete_role(messageID, reaction):
+    roleReact_db = read_roles()
+    if not roleReact_db:
+        print("file is empty")
+        return
+
+    if reaction == "ALL" and messageID in roleReact_db:
+        roleReact_db.pop(messageID)
+
+    elif messageID in roleReact_db and reaction in roleReact_db[messageID]:
+        roleReact_db[messageID].pop(reaction)
+
+    else:
+        return(f"{reaction} reaction for {messageID} is not in database")
+
+    with open(ROLE_FILE, "wb") as file:
+        pickle.dump(roleReact_db, file)
+        print(roleReact_db)
+        return("Done")
+
+#Internal function for checking database for reaction based roles
+def find_role(messageID, reaction):
+    roleReact_db = read_roles()
+    if messageID in roleReact_db:
+        if reaction in roleReact_db[messageID]:
+            return roleReact_db[messageID][reaction]
+
+        else:
+            print(f"{reaction} not in {messageID}")
+            return None
+    else:
+        print(f"messageID {messageID} not found")
+        return None


### PR DESCRIPTION
Added functionality to set a message to grant roles via reaction by message ID.
 `!setBCRoleReaction <MessageID>`: Sets the message that grants roles based on reactions.
 `!unsetBCRoleReaction`: Removes role granting functionality from the currently used message.

A new file named `BCRoleReaction.txt` is made for saving the message ID, and gets deleted when `unsetBCRoleReaction` is used.
The current capacity of messages role reaction messages is 1.

Current roles and reactions:
Catposting `:cat:`
Dogposting `:dog:`
Lizardposting `:lizard:`